### PR TITLE
Add default controller leader election setting values

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/IBM/controller-filtered-cache/filteredcache"
 	v1 "k8s.io/api/core/v1"
@@ -58,6 +59,9 @@ func RunManager() {
 		},
 	}
 
+	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -66,6 +70,9 @@ func RunManager() {
 		LeaderElectionID:        "multicloud-operators-gitopscluster-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
 		NewCache:                filteredcache.NewFilteredCacheBuilder(filteredSecretMap),
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/gitopscluster/exec/options.go
+++ b/cmd/gitopscluster/exec/options.go
@@ -20,11 +20,17 @@ import (
 
 // GitOpsClusterCMDOptions for command line flag parsing
 type GitOpsClusterCMDOptions struct {
-	MetricsAddr string
+	MetricsAddr          string
+	LeaseDurationSeconds int
+	RenewDeadlineSeconds int
+	RetryPeriodSeconds   int
 }
 
 var options = GitOpsClusterCMDOptions{
-	MetricsAddr: "",
+	MetricsAddr:          "",
+	LeaseDurationSeconds: 137,
+	RenewDeadlineSeconds: 107,
+	RetryPeriodSeconds:   26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -36,5 +42,26 @@ func ProcessFlags() {
 		"metrics-addr",
 		options.MetricsAddr,
 		"The address the metric endpoint binds to.",
+	)
+
+	flag.IntVar(
+		&options.LeaseDurationSeconds,
+		"lease-duration",
+		options.LeaseDurationSeconds,
+		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RenewDeadlineSeconds,
+		"renew-deadline",
+		options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RetryPeriodSeconds,
+		"retry-period",
+		options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 }


### PR DESCRIPTION
Following recommended default settings of leaseDuration=137s, renewDeadline=107s, and retryPeriod=26s from https://github.com/openshift/library-go/blob/4b9033d00d37b88393f837a88ff541a56fd13621/pkg/config/leaderelection/leaderelection.go#L84


https://github.com/stolostron/backlog/issues/25245
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>