### PR TITLE
Change lease-duration to leader-election-lease-duration

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -59,7 +59,7 @@ func RunManager() {
 		},
 	}
 
-	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
 	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
 	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/gitopscluster/exec/options.go
+++ b/cmd/gitopscluster/exec/options.go
@@ -20,17 +20,17 @@ import (
 
 // GitOpsClusterCMDOptions for command line flag parsing
 type GitOpsClusterCMDOptions struct {
-	MetricsAddr          string
-	LeaseDurationSeconds int
-	RenewDeadlineSeconds int
-	RetryPeriodSeconds   int
+	MetricsAddr                        string
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
 }
 
 var options = GitOpsClusterCMDOptions{
-	MetricsAddr:          "",
-	LeaseDurationSeconds: 137,
-	RenewDeadlineSeconds: 107,
-	RetryPeriodSeconds:   26,
+	MetricsAddr:                        "",
+	LeaderElectionLeaseDurationSeconds: 137,
+	RenewDeadlineSeconds:               107,
+	RetryPeriodSeconds:                 26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -45,10 +45,10 @@ func ProcessFlags() {
 	)
 
 	flag.IntVar(
-		&options.LeaseDurationSeconds,
-		"lease-duration",
-		options.LeaseDurationSeconds,
-		"The lease duration in seconds.",
+		&options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
 	)
 
 	flag.IntVar(


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

While writing the [doc issue](https://github.com/stolostron/backlog/issues/25868) for https://github.com/stolostron/backlog/issues/25245 I noticed inconsistent naming of the lease duration flag. This change will keep the flag consistent for all the different parts of the controllers.