### PR TITLE
search empty apiversion related items  causes resource sync controlle…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ build:
 	@common/scripts/gobuild.sh build/_output/bin/propagation ./cmd/propagation
 
 local:
+	@GOOS=darwin common/scripts/gobuild.sh build/_output/bin/gitopscluster ./cmd/gitopscluster
 	@GOOS=darwin common/scripts/gobuild.sh build/_output/bin/gitopssyncresc ./cmd/gitopssyncresc
+	@GOOS=darwin common/scripts/gobuild.sh build/_output/bin/multiclusterstatusaggregation ./cmd/multiclusterstatusaggregation
+	@GOOS=darwin common/scripts/gobuild.sh build/_output/bin/propagation ./cmd/propagation
 
 .PHONY: build-images
 


### PR DESCRIPTION
…r crash

The related items returned by search api server could have items with  empty apiversion. It crashed the sync resource controller. 

Also add `kind:Cluster ` item to the exclude list.  It is not used. 

Here is the related item that caused the panic for the ref
```
related: map[count:1 items:[map[
HubAcceptedManagedCluster:True 
ManagedClusterConditionAvailable:True 
ManagedClusterJoined:True 
_hubClusterResource:true 
_uid:cluster__cluster1 
addon:application-manager=true; cert-policy-controller=true; cluster-proxy=true; config-policy-controller=true; governance-policy-framework=true; iam-policy-controller=true; observability-controller=false; search-collector=true; work-manager=true 
apigroup:internal.open-cluster-management.io 
cluster:cluster1 
consoleURL:https://console-openshift-console.apps.app-aws-411ga-sno-net2-7rl5g.dev06.red-chesterfield.com 
cpu:8 
created:2023-03-03T17:19:05Z 
kind:Cluster 
kind_plural:managedclusterinfos 
kubernetesVersion:v1.24.0+9546431 
label:cloud=Amazon; cluster.open-cluster-management.io/clusterset=clusterset1; clusterID=b2597251-be94-41b8-9283-b031b97ec77c; feature.open-cluster-management.io/addon-application-manager=available; feature.open-cluster-management.io/addon-cert-policy-controller=available; feature.open-cluster-management.io/addon-cluster-proxy=available; feature.open-cluster-management.io/addon-config-policy-controller=available; feature.open-cluster-management.io/addon-governance-policy-framework=available; feature.open-cluster-management.io/addon-iam-policy-controller=available; feature.open-cluster-management.io/addon-search-collector=available; feature.open-cluster-management.io/addon-work-manager=available; name=cluster1; openshiftVersion=4.11.0; openshiftVersion-major=4; openshiftVersion-major-minor=4.11; vendor=OpenShift 
memory:32555512Ki 
name:cluster1 
nodes:1]] kind:Cluster]
```