### PR TITLE
Handle resources that do not have an apiversion

### DIFF
--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -95,7 +95,7 @@ type GitOpsSyncResource struct {
 	DataSender  DataSender
 }
 
-var ExcludeResourceList = []string{"ApplicationSet", "Application", "EndpointSlice", "Pod", "ReplicaSet"}
+var ExcludeResourceList = []string{"ApplicationSet", "Application", "Cluster", "EndpointSlice", "Pod", "ReplicaSet"}
 
 // Add creates a new argocd cluster Controller and adds it to the Manager with default RBAC.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -510,9 +510,9 @@ func getResourceRef(relatedItem map[string]interface{}) *appsetreport.ResourceRe
 	}
 
 	repRef := &appsetreport.ResourceRef{
-		APIVersion: apigroup + relatedItem["apiversion"].(string),
-		Kind:       relatedItem["kind"].(string),
-		Name:       relatedItem["name"].(string),
+		APIVersion: apigroup + fmt.Sprintf("%v", relatedItem["apiversion"]),
+		Kind:       fmt.Sprintf("%v", relatedItem["kind"]),
+		Name:       fmt.Sprintf("%v", relatedItem["name"]),
 		Namespace:  namespace,
 	}
 

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
@@ -85,6 +85,7 @@ const responseData1 = `
 						 "ManagedClusterJoined":"True",
 						 "apigroup":"internal.open-cluster-management.io",
 						 "cpu":"8",
+						 "cluster":"cluster1",
 						 "kind":"Cluster",
 						 "kind_plural":"managedclusterinfos",
 						 "name":"cluster1"


### PR DESCRIPTION
Search returns cluster in the related items, which does not contain apiversion. This resource item used to be excluded because it does not contain the cluster property, but that property has been added recently, causing the resource sync controller to crash.