### PR TITLE
ACM-4395 Truncate hosting appset label to align with character limit

### DIFF
--- a/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
+++ b/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
@@ -261,7 +261,7 @@ func (r *ReconcilePullModelAggregation) generateAppSetReport(appSetClusterStatus
 		)
 
 		loadYAML := true
-		reportName := filepath.Join(r.ResourceDir, fmt.Sprintf("%.63s", appsetNs+"_"+appsetName)+".yaml")
+		reportName := filepath.Join(r.ResourceDir, appsetNs+"_"+appsetName+".yaml")
 		testappSetCRD, err := loadAppSetCRD(reportName)
 
 		if err != nil {


### PR DESCRIPTION
This PR is for only truncating the hosting-appset label and **NOT** the YAML file name.

Addresses:
 - https://issues.redhat.com/browse/ACM-4395