### PR TITLE
Replace aggregation controller client with non-caching client

### DIFF
--- a/cmd/multiclusterstatusaggregation/exec/manager.go
+++ b/cmd/multiclusterstatusaggregation/exec/manager.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
@@ -80,6 +82,7 @@ func RunManager() {
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		NewClient:               NewNonCachingClient,
 	})
 
 	if err != nil {
@@ -133,4 +136,8 @@ func RunManager() {
 		klog.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+func NewNonCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	return client.New(config, client.Options{})
 }


### PR DESCRIPTION
This PR replaces the default cached client for the multiclusterStatusAggregation controller with a non-cached client. Addresses potential Out of memory issues with busy environments.