### PR TITLE
Update leader election settings

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/IBM/controller-filtered-cache/filteredcache"
 	v1 "k8s.io/api/core/v1"
@@ -60,9 +59,11 @@ func RunManager() {
 		},
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -71,9 +72,9 @@ func RunManager() {
 		LeaderElectionID:        "multicloud-operators-gitopscluster-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
 		NewCache:                filteredcache.NewFilteredCacheBuilder(filteredSecretMap),
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/gitopscluster/exec/options.go
+++ b/cmd/gitopscluster/exec/options.go
@@ -15,22 +15,24 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // GitOpsClusterCMDOptions for command line flag parsing
 type GitOpsClusterCMDOptions struct {
-	MetricsAddr                        string
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = GitOpsClusterCMDOptions{
-	MetricsAddr:                        "",
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -44,24 +46,31 @@ func ProcessFlags() {
 		"The address the metric endpoint binds to.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/cmd/gitopssyncresc/exec/manager.go
+++ b/cmd/gitopssyncresc/exec/manager.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -51,9 +50,11 @@ func RunManager() {
 		klog.Info("LeaderElection disabled as not running in a cluster")
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -61,9 +62,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-gitopssyncresc-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/gitopssyncresc/exec/options.go
+++ b/cmd/gitopssyncresc/exec/options.go
@@ -15,26 +15,28 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // GitOpsClusterCMDOptions for command line flag parsing
 type GitOpsSyncRescCMDOptions struct {
-	MetricsAddr                        string
-	SyncInterval                       int
-	AppSetResourceDir                  string
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	SyncInterval                int
+	AppSetResourceDir           string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = GitOpsSyncRescCMDOptions{
-	MetricsAddr:                        "",
-	SyncInterval:                       10,
-	AppSetResourceDir:                  "/var/appset-resc",
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	SyncInterval:                10,
+	AppSetResourceDir:           "/var/appset-resc",
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -62,24 +64,31 @@ func ProcessFlags() {
 		"The directory for persisting appset resource files.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/cmd/multiclusterstatusaggregation/exec/manager.go
+++ b/cmd/multiclusterstatusaggregation/exec/manager.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"time"
 
 	manifestWorkV1 "open-cluster-management.io/api/work/v1"
 	appsubapi "open-cluster-management.io/multicloud-integrations/pkg/apis"
@@ -70,19 +69,20 @@ func RunManager() {
 		}
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		Port:                    operatorMetricsPort,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-multiclusterstatusaggregation-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
-		NewClient:               NewNonCachingClient,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/multiclusterstatusaggregation/exec/options.go
+++ b/cmd/multiclusterstatusaggregation/exec/options.go
@@ -15,28 +15,30 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // PlacementRuleCMDOptions for command line flag parsing
 type PullModelAggregationCMDOptions struct {
-	MetricsAddr                        string
-	KubeConfig                         string
-	AppSetResourceDir                  string
-	SyncInterval                       int
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	KubeConfig                  string
+	AppSetResourceDir           string
+	SyncInterval                int
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = PullModelAggregationCMDOptions{
-	MetricsAddr:                        "",
-	KubeConfig:                         "",
-	AppSetResourceDir:                  "/var/appset-resc",
-	SyncInterval:                       10,
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	KubeConfig:                  "",
+	AppSetResourceDir:           "/var/appset-resc",
+	SyncInterval:                10,
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -71,24 +73,31 @@ func ProcessFlags() {
 		"The interval of housekeeping in seconds.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/cmd/propagation/main.go
+++ b/cmd/propagation/main.go
@@ -43,17 +43,17 @@ import (
 
 // PropagationCMDOptions for command line flag parsing
 type PropagationCMDOptions struct {
-	MetricsAddr                        string
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = PropagationCMDOptions{
-	MetricsAddr:                        "",
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 var (
@@ -80,25 +80,32 @@ func main() {
 		"The address the metric endpoint binds to.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 	opts := zap.Options{
 		Development: true,
@@ -108,9 +115,11 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	setupLog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
@@ -119,9 +128,9 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-propagation-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/deploy/controller/deploy.yaml
+++ b/deploy/controller/deploy.yaml
@@ -21,9 +21,9 @@ spec:
       - command:
         - /usr/local/bin/gitopscluster
         - --alsologtostderr
-        - --leader-election-lease-duration=137
-        - --renew-deadline=107
-        - --retry-period=26
+        - --leader-election-lease-duration=137s
+        - --leader-election-renew-deadline=107s
+        - --leader-election-retry-period=26s
         image: quay.io/open-cluster-management/multicloud-integrations:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/deploy/controller/operator.yaml
+++ b/deploy/controller/operator.yaml
@@ -22,6 +22,9 @@ spec:
         command:
         - /usr/local/bin/gitopssyncresc
         - --appset-resource-dir=/etc/gitops-resources
+        - --leader-election-lease-duration=137s
+        - --leader-election-renew-deadline=107s
+        - --leader-election-retry-period=26s
         env:
         - name: WATCH_NAMESPACE
         - name: POD_NAME
@@ -65,6 +68,9 @@ spec:
         command:
         - /usr/local/bin/multiclusterstatusaggregation
         - --appset-resource-dir=/etc/gitops-resources
+        - --leader-election-lease-duration=137s
+        - --leader-election-renew-deadline=107s
+        - --leader-election-retry-period=26s
         env:
         - name: WATCH_NAMESPACE
         - name: POD_NAME
@@ -107,6 +113,9 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/propagation
+        - --leader-election-lease-duration=137s
+        - --leader-election-renew-deadline=107s
+        - --leader-election-retry-period=26s
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
This PR updates the leader election settings and renames the leader election options from 
``` 
--renew-deadline ==> leader-election-renew-deadline
--retry-period ==> leader-election-retry-period
```