### PR TITLE
Added required permissions

### DIFF
--- a/deploy/controller/role.yaml
+++ b/deploy/controller/role.yaml
@@ -54,6 +54,7 @@ rules:
       - subscriptions/status
       - subscriptionstatuses
       - subscriptionreports
+      - multiclusterapplicationsetreports
   - verbs:
       - get
       - list
@@ -68,6 +69,7 @@ rules:
     resources:
       - applications
       - applications/status
+      - applicationsets
   - verbs:
       - get
       - list


### PR DESCRIPTION
Description:
When the operator was run in a kubernetes cluster, it reported an error about missing permissions on applicationsets and multiclusterapplicationsetreports.

Changes:
- added support for applicationsets and multiclusterapplicationsetreports resources in role permissions