### PR TITLE
apply non cached client to pull/push model controllers

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -27,9 +27,12 @@ import (
 	"open-cluster-management.io/multicloud-integrations/pkg/controller"
 	"open-cluster-management.io/multicloud-integrations/pkg/utils"
 
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
@@ -75,6 +78,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
+		NewClient:               NewNonCachingClient,
 	})
 
 	if err != nil {
@@ -123,4 +127,8 @@ func RunManager() {
 		klog.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+func NewNonCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	return client.New(config, client.Options{Scheme: scheme.Scheme})
 }

--- a/cmd/multiclusterstatusaggregation/exec/manager.go
+++ b/cmd/multiclusterstatusaggregation/exec/manager.go
@@ -139,5 +139,5 @@ func RunManager() {
 }
 
 func NewNonCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
-	return client.New(config, client.Options{})
+	return client.New(config, client.Options{Scheme: clientgoscheme.Scheme})
 }

--- a/cmd/propagation/main.go
+++ b/cmd/propagation/main.go
@@ -35,10 +35,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"k8s.io/client-go/rest"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	argov1alpha1 "open-cluster-management.io/multicloud-integrations/pkg/apis/argocd/v1alpha1"
 	"open-cluster-management.io/multicloud-integrations/propagation-controller/application"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // PropagationCMDOptions for command line flag parsing
@@ -131,6 +134,7 @@ func main() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
+		NewClient:               NewNonCachingClient,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -169,4 +173,8 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func NewNonCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	return client.New(config, client.Options{Scheme: scheme})
 }


### PR DESCRIPTION
The non cached client is applied to the following clients in order to avoid them hit OOM killed issue in scale test where 2500 managed clusters are imported.
- gitopscluster controller in push model
- propagation controller in pull model
- aggregation controller in pull model

Note the runtime scheme is required to be declared when the non cached client is created