### PR TITLE
Add non-cached client to aggregation controller

### DIFF
--- a/cmd/multiclusterstatusaggregation/exec/manager.go
+++ b/cmd/multiclusterstatusaggregation/exec/manager.go
@@ -83,6 +83,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
+		NewClient:               NewNonCachingClient,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR adds the Non-Cached client to the manager of the aggregation controller.