### PR TITLE
Adding support for cluster domain root when creating URL

### DIFF
--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -49,9 +49,11 @@ import (
 )
 
 const (
-	SearchServiceName = "search-search-api"
-	SearchDefaultNs   = "open-cluster-management"
-	AccessToken       = "ACCESS_TOKEN"
+	SearchServiceName        = "search-search-api"
+	SearchDefaultNs          = "open-cluster-management"
+	AccessToken              = "ACCESS_TOKEN"
+	ClusterRootDomainEnv     = "CLUSTER_ROOT_DOMAIN"
+	ClusterRootDomainDefault = "cluster.local"
 )
 
 type DataSender interface {
@@ -253,7 +255,8 @@ func (r *GitOpsSyncResource) getSearchURL() (string, error) {
 
 	targetPort := svc.Spec.Ports[0].TargetPort.IntVal
 
-	return fmt.Sprintf("https://%v.%v.svc.cluster.local:%v/searchapi/graphql", SearchServiceName, searchNs, targetPort), nil
+	return fmt.Sprintf("https://%v.%v.svc.%v:%v/searchapi/graphql", SearchServiceName, searchNs,
+		getEnv(ClusterRootDomainEnv, ClusterRootDomainDefault), targetPort), nil
 }
 
 func (r *GitOpsSyncResource) getArgoAppsFromSearch(clusters []string, appsetNs, appsetName string) ([]interface{}, []interface{}, error) {
@@ -563,4 +566,13 @@ func getResourceRef(relatedItem map[string]interface{}) *appsetreport.ResourceRe
 	}
 
 	return repRef
+}
+
+func getEnv(key, defaultValue string) string {
+	value, exists := os.LookupEnv(key)
+	if !exists || len(value) == 0 {
+		return defaultValue
+	}
+
+	return value
 }

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
@@ -277,7 +277,8 @@ func TestGitOpsSyncResource_getSearchURL(t *testing.T) {
 		{
 			name:    "Search service exists",
 			service: searchSvc,
-			want:    fmt.Sprintf("https://%v.%v.svc.cluster.local:%v/searchapi/graphql", SearchServiceName, SearchDefaultNs, 8080),
+			want: fmt.Sprintf("https://%v.%v.svc.%v:%v/searchapi/graphql", SearchServiceName, SearchDefaultNs,
+				getEnv(ClusterRootDomainEnv, ClusterRootDomainDefault), 8080),
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Hi,
we need a custom cluster domain when creating an URL for Search API.

My changes are only a concept, I would like to make a discussion here about more permanent changes:
1st way: Completely omit the root domain, so use svc.ns.svc only, not sure all clusters have default search root cluster domain inside  /etc/resolv.conf
2nd way: Adding another cli option, but I don't really like adding more direct options to the method input, it would be fine to have the configuration object accessible in the manager directly, instead of this, or are you of a different opinion?
```
// Setup all Controllers
if err := controller.AddGitOpsSyncRescToManager(mgr, options.SyncInterval, options.AppSetResourceDir, options. ClusterRootDomain); err != nil {
	klog.Error(err, "")
	os.Exit(1)
}
```