### PR TITLE
Only initialize map of clusters per appset once

### DIFF
--- a/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
+++ b/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
@@ -177,9 +177,11 @@ func (r *ReconcilePullModelAggregation) generateAggregation() error {
 				klog.Warningf("Appset namespace: %v , Appset name: %v", appsetNs, appsetName)
 			}
 
-			// Need to allocate a map of clusters for each appset
+			// Need to allocate a map of clusters for each appset only once.
 			appSetKey := AppSet{types.NamespacedName{Namespace: appsetNs, Name: appsetName}}
-			appSetClusterStatusMap[appSetKey] = make(map[Cluster]OverallStatus)
+			if _, ok := appSetClusterStatusMap[appSetKey]; !ok {
+				appSetClusterStatusMap[appSetKey] = make(map[Cluster]OverallStatus)
+			}
 		}
 
 		for _, manifestWork := range appSetClusterList.Items {


### PR DESCRIPTION
This PR only initializes the map of clusters to map of appsets once, so each subsequent pass doesn't overwrite the existing data. 