### PR TITLE
Cleanup orphaned manifestWorks in the background

### DIFF
--- a/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
+++ b/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
@@ -603,9 +603,10 @@ func (r *ReconcilePullModelAggregation) cleanupOrphanReports() error {
 		errOccured := false
 
 		if workList.Items != nil && len(workList.Items) > 0 {
+			deleteInBackground := metav1.DeletePropagationBackground
 			for w := range workList.Items {
 				// Remove ManifestWork
-				if err := r.Delete(context.TODO(), &workList.Items[w]); err != nil {
+				if err := r.Delete(context.TODO(), &workList.Items[w], &client.DeleteOptions{PropagationPolicy: &deleteInBackground}); err != nil {
 					if !errors.IsNotFound(err) {
 						klog.Info("Couldn't delete ManifestWork", err)
 


### PR DESCRIPTION
This PR is to set the deleteOptions for cleaning up manifestWorks to delete in the background.