### PR TITLE
Detect if ManagedServiceAccount CRD exists before watching

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -126,6 +126,9 @@ func RunManager() {
 	klog.Info("Detecting ACM cluster API service...")
 	utils.DetectClusterRegistry(sig, mgr.GetAPIReader())
 
+	klog.Info("Detecting ACM managedServiceAccount API...")
+	utils.DetectManagedServiceAccount(sig, mgr.GetAPIReader())
+
 	klog.Info("Starting the Cmd.")
 
 	// Start the Cmd

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,8 @@ require (
 	k8s.io/client-go v0.24.11
 	k8s.io/klog v1.0.0
 	open-cluster-management.io/api v0.10.0
+	open-cluster-management.io/managed-serviceaccount v0.2.0
 	sigs.k8s.io/controller-runtime v0.12.3
-)
-
-require (
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	open-cluster-management.io/managed-serviceaccount v0.2.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -366,7 +366,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -1068,7 +1067,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -172,12 +172,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 
 		// Watch changes to Managed service account's tokenSecretRef
-		err = c.Watch(
-			&source.Kind{Type: &authv1alpha1.ManagedServiceAccount{}},
-			&handler.EnqueueRequestForObject{},
-			utils.ManagedServiceAccountPredicateFunc)
-		if err != nil {
-			return err
+		if utils.IsReadyManagedServiceAccount(mgr.GetAPIReader()) {
+			err = c.Watch(
+				&source.Kind{Type: &authv1alpha1.ManagedServiceAccount{}},
+				&handler.EnqueueRequestForObject{},
+				utils.ManagedServiceAccountPredicateFunc)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
* [x] I have taken backward compatibility into consideration.

This PR is to detect if the `managedServiceAccount` exists before setting a watch for the resource. Once the resource is detected, the controller will automatically restart.

Addresses issue: https://github.com/stolostron/backlog/issues/27307
