### PR TITLE
set up log level to 1 to avoid massively logging

### DIFF
--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -188,7 +188,7 @@ func (r *GitOpsSyncResource) syncResources() error {
 
 				// Skip application that don't belong to an appset
 				if hostingAppsetName == nil {
-					klog.Infof("skip application %v/%v on cluster %v, it does not belong to an appset", itemmap["namespace"], itemmap["name"], managedClusterName)
+					klog.V(1).Infof("skip application %v/%v on cluster %v, it does not belong to an appset", itemmap["namespace"], itemmap["name"], managedClusterName)
 					return nil
 				}
 


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

 this pod is massively logging in one customer site. Since there is no applicationSet used there, customer doesn't care about the message.
