### PR TITLE
The server url is missed when generating OCP cluster secret

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -1008,6 +1008,8 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretInArgo(argoNamespace 
 
 				return nil, err
 			}
+		} else {
+			clusterURL = string(managedClusterSecret.Data["server"])
 		}
 
 		labels := managedClusterSecret.GetLabels()


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
