### PR TITLE
feat: propagation controller now have the ability to propagate the Application operation field

### DIFF
--- a/e2e/hub_app/guestbook-app-set.yaml
+++ b/e2e/hub_app/guestbook-app-set.yaml
@@ -11,11 +11,21 @@ spec:
           matchLabels:
             cluster.open-cluster-management.io/placement: guestbook-app-placement
         requeueAfterSeconds: 10
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        - matchExpressions:
+            - key: envLabel
+              operator: In
+              values:
+                - env-dev
   template:
     metadata:
       name: '{{name}}-guestbook-app'
       labels:
         apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'
+        envLabel: 'env-dev'
       annotations:
         argocd.argoproj.io/skip-reconcile: 'true'
         apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'
@@ -30,7 +40,5 @@ spec:
         server: https://kubernetes.default.svc
         namespace: guestbook
       syncPolicy:
-        automated:
-          prune: true
         syncOptions:
           - CreateNamespace=true

--- a/propagation-controller/application/helper.go
+++ b/propagation-controller/application/helper.go
@@ -130,6 +130,7 @@ func getAppSetOwnerName(ownerRefs []metav1.OwnerReference) string {
 // - reset the meta
 // - set the namespace value
 // - ensures the Application Destination is set to in-cluster resource deployment
+// - ensures the operation field is also set if present
 func prepareApplicationForWorkPayload(application *unstructured.Unstructured) unstructured.Unstructured {
 	newApp := &unstructured.Unstructured{}
 	newApp.SetGroupVersionKind(schema.GroupVersionKind{
@@ -141,6 +142,12 @@ func prepareApplicationForWorkPayload(application *unstructured.Unstructured) un
 	newApp.SetName(application.GetName())
 	newApp.SetFinalizers(application.GetFinalizers())
 
+	// set the operation field
+	if operation, ok := application.Object["operation"].(map[string]interface{}); ok {
+		newApp.Object["operation"] = operation
+	}
+
+	// set the spec field
 	if newSpec, ok := application.Object["spec"].(map[string]interface{}); ok {
 		if destination, ok := newSpec["destination"].(map[string]interface{}); ok {
 			// empty the name

--- a/propagation-controller/application/helper_test.go
+++ b/propagation-controller/application/helper_test.go
@@ -314,6 +314,24 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 			"server": "originalServer",
 		},
 	}
+	app.Object["operation"] = map[string]interface{}{
+		"info": []interface{}{
+			map[string]interface{}{
+				"name":  "Reason",
+				"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+			},
+		},
+		"initiatedBy": map[string]interface{}{
+			"automated": true,
+			"username":  "applicationset-controller",
+		},
+		"retry": map[string]interface{}{},
+		"sync": map[string]interface{}{
+			"syncOptions": []interface{}{
+				"CreateNamespace=true",
+			},
+		},
+	}
 
 	type args struct {
 		application *unstructured.Unstructured
@@ -344,6 +362,24 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 						"server": KubernetesInternalAPIServerAddr,
 					},
 				}
+				expectedApp.Object["operation"] = map[string]interface{}{
+					"info": []interface{}{
+						map[string]interface{}{
+							"name":  "Reason",
+							"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+						},
+					},
+					"initiatedBy": map[string]interface{}{
+						"automated": true,
+						"username":  "applicationset-controller",
+					},
+					"retry": map[string]interface{}{},
+					"sync": map[string]interface{}{
+						"syncOptions": []interface{}{
+							"CreateNamespace=true",
+						},
+					},
+				}
 				return expectedApp
 			}(),
 		},
@@ -369,6 +405,13 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 
 			if !reflect.DeepEqual(gotSpec, wantSpec) {
 				t.Errorf("prepareApplicationForWorkPayload() Spec = %v, want %v", gotSpec, wantSpec)
+			}
+
+			gotOperation, _, _ := unstructured.NestedMap(got.Object, "operation")
+			wantOperation, _, _ := unstructured.NestedMap(tt.want.Object, "operation")
+
+			if !reflect.DeepEqual(gotOperation, wantOperation) {
+				t.Errorf("prepareApplicationForWorkPayload() Operation = %v, want %v", gotOperation, wantOperation)
 			}
 
 			if !reflect.DeepEqual(got.GetLabels(), tt.want.GetLabels()) {


### PR DESCRIPTION
- feat: propagation controller now have the ability to propagate the Application operation field.
- Also updated the e2e propagation test to use AppSet progressive sync instead of automated sync.
- Since automated sync is now turned off in e2e test appset, the test will only pass when the operation field is properly propagated which triggers a sync.

* [x] I have taken backward compatibility into consideration.
