### PR TITLE
Disable TLS and set insecure to true

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -944,7 +944,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 			if msaExists {
 				newSecret, err = r.CreateMangedClusterSecretFromManagedServiceAccount(
-					argoNamespace, managedCluster, componentName)
+					argoNamespace, managedCluster, componentName, false)
 			} else {
 				newSecret, err = r.CreateManagedClusterSecretInArgo(
 					argoNamespace, managedClusterSecret, managedCluster, createBlankClusterSecrets)
@@ -961,7 +961,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 		} else {
 			klog.Infof("create cluster secret using managed service account: %s/%s", managedCluster.Name, gitOpsCluster.Spec.ManagedServiceAccountRef)
 
-			newSecret, err = r.CreateMangedClusterSecretFromManagedServiceAccount(argoNamespace, managedCluster, gitOpsCluster.Spec.ManagedServiceAccountRef)
+			newSecret, err = r.CreateMangedClusterSecretFromManagedServiceAccount(argoNamespace, managedCluster, gitOpsCluster.Spec.ManagedServiceAccountRef, true)
 			if err != nil {
 				klog.Error("failed to create managed cluster secret. err: ", err.Error())
 
@@ -1110,7 +1110,7 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretInArgo(argoNamespace 
 }
 
 func (r *ReconcileGitOpsCluster) CreateMangedClusterSecretFromManagedServiceAccount(argoNamespace string,
-	managedCluster *spokeclusterv1.ManagedCluster, managedServiceAccountRef string) (*v1.Secret, error) {
+	managedCluster *spokeclusterv1.ManagedCluster, managedServiceAccountRef string, enableTLS bool) (*v1.Secret, error) {
 	// Find managedserviceaccount in the managed cluster namespace
 	account := &authv1beta1.ManagedServiceAccount{}
 	if err := r.Get(context.TODO(), types.NamespacedName{Name: managedServiceAccountRef, Namespace: managedCluster.Name}, account); err != nil {
@@ -1137,13 +1137,21 @@ func (r *ReconcileGitOpsCluster) CreateMangedClusterSecretFromManagedServiceAcco
 
 	clusterSecretName := fmt.Sprintf("%v-%v-cluster-secret", managedCluster.Name, managedServiceAccountRef)
 
+	tlsClientConfig := map[string]interface{}{
+		"insecure": true,
+	}
 	caCrt := base64.StdEncoding.EncodeToString(tokenSecret.Data["ca.crt"])
-	config := map[string]interface{}{
-		"bearerToken": string(tokenSecret.Data["token"]),
-		"tlsClientConfig": map[string]interface{}{
+
+	if enableTLS {
+		tlsClientConfig = map[string]interface{}{
 			"insecure": false,
 			"caData":   caCrt,
-		},
+		}
+	}
+
+	config := map[string]interface{}{
+		"bearerToken":     string(tokenSecret.Data["token"]),
+		"tlsClientConfig": tlsClientConfig,
 	}
 
 	encodedConfig, err := json.Marshal(config)

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -1440,7 +1440,7 @@ func TestCreateMangedClusterSecretFromManagedServiceAccount(t *testing.T) {
 
 	// No managed service account
 	_, err = gitopsc.(*ReconcileGitOpsCluster).CreateMangedClusterSecretFromManagedServiceAccount(
-		argocdServerNamespace1.Name, managedCluster1, msa.Name)
+		argocdServerNamespace1.Name, managedCluster1, msa.Name, true)
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.MatchRegexp("ManagedServiceAccount.authentication.open-cluster-management.io.*not found"))
 
@@ -1454,7 +1454,7 @@ func TestCreateMangedClusterSecretFromManagedServiceAccount(t *testing.T) {
 
 	// No tokenSecretRef
 	_, err = gitopsc.(*ReconcileGitOpsCluster).CreateMangedClusterSecretFromManagedServiceAccount(
-		argocdServerNamespace1.Name, mc1, msa.Name)
+		argocdServerNamespace1.Name, mc1, msa.Name, true)
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.Equal("no token reference secret found in the managed service account: cluster1/managedserviceaccount1"))
 
@@ -1473,7 +1473,7 @@ func TestCreateMangedClusterSecretFromManagedServiceAccount(t *testing.T) {
 
 	// Cluster secret created from the managed service account
 	clusterSecret, err := gitopsc.(*ReconcileGitOpsCluster).CreateMangedClusterSecretFromManagedServiceAccount(
-		argocdServerNamespace1.Name, mc1, msa.Name)
+		argocdServerNamespace1.Name, mc1, msa.Name, true)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	data := make(map[string]interface{})
@@ -1494,7 +1494,7 @@ func TestCreateMangedClusterSecretFromManagedServiceAccount(t *testing.T) {
 
 	// Cluster secret update from the managed service account
 	clusterSecret, err = gitopsc.(*ReconcileGitOpsCluster).CreateMangedClusterSecretFromManagedServiceAccount(
-		argocdServerNamespace1.Name, mc1, msa.Name)
+		argocdServerNamespace1.Name, mc1, msa.Name, true)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(json.Unmarshal([]byte(clusterSecret.StringData["config"]), &data)).NotTo(gomega.HaveOccurred())
 	g.Expect(data["bearerToken"].(string)).To(gomega.Equal("token2"))


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

- Disable TLS and set insecure to true

I wanted to keep the original behaviour so I added a bool to CreateMangedClusterSecretFromManagedServiceAccount() to toggle between enable/disable TLS.