### PR TITLE
gitops addon ManagedClusterAddOn failure with ManagedClusterAddOnLeas…

### DIFF
--- a/cmd/propagation/main.go
+++ b/cmd/propagation/main.go
@@ -58,7 +58,7 @@ var options = PropagationCMDOptions{
 	LeaderElectionLeaseDuration: 137 * time.Second,
 	LeaderElectionRenewDeadline: 107 * time.Second,
 	LeaderElectionRetryPeriod:   26 * time.Second,
-	MaxConcurrentReconciles:     10,
+	MaxConcurrentReconciles:     1,
 }
 
 var (

--- a/gitopsaddon/addonTemplates/clusterManagementAddon.yaml
+++ b/gitopsaddon/addonTemplates/clusterManagementAddon.yaml
@@ -2,8 +2,6 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ClusterManagementAddOn
 metadata:
   name: gitops-addon
-  annotations:
-    addon.open-cluster-management.io/lifecycle: "gitops-addon"
 spec:
   addOnMeta:
     description: gitops-addon


### PR DESCRIPTION
…eNotFound error, disable concurrent reconcile for ArgoCD pull model propagation controller

* [X] I have taken backward compatibility into consideration.

Two fixes are included:

https://issues.redhat.com/browse/ACM-20204
https://issues.redhat.com/browse/ACM-19762
